### PR TITLE
Add overscan to list to prerender items coming into view for slower devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Useful for those super important business applications where one must show all m
 | **`data`** | _Array_ | List of data items |
 | **`renderRow`** | _Function_ | Renders a single row |
 | **`rowHeight`** | _Number_ | Static height of a row |
+| **`overscanCount`** | _Number_ | Amount of rows to render above and below visible area of the list `default: 10` |
 | **`sync`** | _Boolean_ | If `true`, forces synchronous rendering \* |
 
 > _**A note on synchronous rendering:** It's best to try without `sync` enabled first. If the normal async rendering behavior is fine, it's best to leave sync turned off. If you're seeing flickering, enabling sync will ensure every update gets out to the screen without dropping renders, but does so at the expense of actual framerate._
@@ -31,7 +32,8 @@ Useful for those super important business applications where one must show all m
 <VirtualList
     data={['a', 'b', 'c']}
     renderRow={ row => <div>{row}</div> }
-    rowHeight={22}
+    rowHeight={22},
+	overscanCount={10}
     sync
 />
 ```

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Useful for those super important business applications where one must show all m
     data={['a', 'b', 'c']}
     renderRow={ row => <div>{row}</div> }
     rowHeight={22},
-	overscanCount={10}
+    overscanCount={10}
     sync
 />
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ const STYLE_CONTENT = 'position:absolute; top:0; left:0; height:100%; width:100%
  *	@param {Array<*>} data         List of data items
  *	@param {Function} renderRow    Renders a single row
  *	@param {Number} rowHeight      Static height of a row
+ *	@param {Number} overscanCount  Amount of rows to render above and below list
  *	@param {Boolean} [sync=false]  true forces synchronous rendering
  *	@example
  *		<VirtualList
@@ -42,15 +43,16 @@ export default class VirtualList extends Component {
 		removeEventListener('resize', this.resize);
 	}
 
-	render({ data, rowHeight, renderRow, ...props }, { offset=0, height=0 }) {
+	render({ data, rowHeight, renderRow, overscanCount = 10, ...props }, { offset=0, height=0 }) {
+
 		// first visible row index
 		let start = (offset / rowHeight)|0;
 
 		// last visible row index
 		let end = start + 1 + (height / rowHeight)|0;
 
-		// data slice currently in viewport
-		let selection = data.slice(start, end);
+		// data slice currently in viewport plus overscan items
+		let selection = data.slice(Math.max(0, start - overscanCount), end + overscanCount);
 
 		return (
 			<div onScroll={this.handleScroll} {...props}>

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ const STYLE_CONTENT = 'position:absolute; top:0; left:0; height:100%; width:100%
  *	@param {Array<*>} data         List of data items
  *	@param {Function} renderRow    Renders a single row
  *	@param {Number} rowHeight      Static height of a row
- *	@param {Number} overscanCount  Amount of rows to render above and below list
+ *	@param {Number} overscanCount  Amount of rows to render above and below visible area of the list
  *	@param {Boolean} [sync=false]  true forces synchronous rendering
  *	@example
  *		<VirtualList

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,6 @@ export default class VirtualList extends Component {
 	}
 
 	render({ data, rowHeight, renderRow, overscanCount = 10, ...props }, { offset=0, height=0 }) {
-
 		// first visible row index
 		let start = (offset / rowHeight)|0;
 


### PR DESCRIPTION
Adding overscan items should help with the problem of empty space showing above and below the list depending on scroll direction.  I picked an arbitrary default of 10 which seemed to work well in my testing.

You can see the code from the pull running here: https://jsfiddle.net/wh4t5e84
